### PR TITLE
[ci] deploy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - make html
   - make latex
   - cd build/latex
-  - LATEXNAME=Meshroom
+  - LATEXNAME=meshroom
   - pdflatex -interaction nonstopmode -halt-on-error -file-line-error  ${LATEXNAME}.tex
 
   # in case there are other latex packages to install texliveonfly will do the


### PR DESCRIPTION
Apparently on travis the latex file is generated all small caps.
So
```
LATEXNAME=meshroom
```

fix #5 